### PR TITLE
Dev

### DIFF
--- a/perception/terminals.py
+++ b/perception/terminals.py
@@ -637,6 +637,7 @@ def get_autoencoder(retrain=False):
     Returns:
         SimpleAutoencoder: The global autoencoder instance
     """
+    global _global_autoencoder
 
     model_path = "/tmp/recon_autoencoder.pkl"
 

--- a/viz/app_streamlit.py
+++ b/viz/app_streamlit.py
@@ -94,7 +94,7 @@ class ReCoNSimulation:
 
     def generate_scene(self):
         """Generate a new synthetic scene and initialize terminals."""
-        img, tvals = sample_scene_and_terminals()  # scene_img is returned
+        img, tvals = sample_scene_and_terminals()  # img is the scene image
         # seed terminals
         for term_id, term_val in tvals.items():
             self.graph.units[term_id].a = float(term_val)


### PR DESCRIPTION
This pull request introduces a new `TinyCNN` feature learner to the `perception/terminals.py` module, providing a simple, unsupervised convolutional neural network for extracting additional features from images. It also adds comprehensive tests for this new feature in `tests/test_terminals.py`. Additionally, the pull request refactors variable naming throughout `viz/app_streamlit.py` to improve code clarity and consistency, especially for unit and terminal identifiers.

The most important changes are:

### New Feature: TinyCNN Convolutional Feature Learner

* Added the `TinyCNN` class to `perception/terminals.py`, implementing an unsupervised, online-learning convolutional feature extractor using Hebbian/Oja's rule, with methods for training, encoding, saving, and loading filter weights. Also includes global instance management and integration functions for extracting CNN-based terminal features from images.

* Added the `deep_comprehensive_terminals_from_image` function to combine advanced, autoencoder, and new CNN-based features into a single set of terminal features.

### Testing

* Added a new `TestTinyCNN` test class to `tests/test_terminals.py` with tests covering initialization, training, encoding, saving/loading, and integration of CNN-based terminals, ensuring correctness and robustness of the new feature.

### Code Quality and Refactoring

* Refactored variable names throughout `viz/app_streamlit.py` for clarity, especially renaming generic variables like `unit`, `tid`, and `val` to more descriptive names such as `graph_unit`, `term_id`, `term_value`, etc., improving code readability and maintainability. [[1]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L71-R78) [[2]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L95-R102) [[3]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L115-R119) [[4]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L232-R242) [[5]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L261-R274) [[6]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L284-R292) [[7]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L316-R324) [[8]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L360-R373) [[9]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L397-R404) [[10]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L649-R654) [[11]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L681-R690) [[12]](diffhunk://#diff-129cc6b002ea15eb69fdbbefd98f01a998f6b30056669284be791e13fea4fe61L723-R734)

### Minor Fix

* Added a missing `global _global_autoencoder` declaration in `get_autoencoder` for proper global state management.