### PR TITLE
Generate complex synthetic scenes for perception testing

### DIFF
--- a/perception/dataset.py
+++ b/perception/dataset.py
@@ -70,6 +70,78 @@ def draw_triangle(img, x, y, base, height, val=1.0):
     return img
 
 
+def draw_trapezoid(img, top_x, top_w, base_x, base_w, y, h, val=1.0):
+    """
+    Draw a filled vertical trapezoid by scanlines.
+
+    The shape is defined by a top edge at row y with width top_w starting at top_x,
+    and a base edge at row y+h-1 with width base_w starting at base_x. Intermediate
+    rows linearly interpolate both the starting x and width.
+
+    Args:
+        img: Image array to draw on (modified in-place)
+        top_x: Left x-coordinate of the top edge
+        top_w: Width of the top edge
+        base_x: Left x-coordinate of the base edge
+        base_w: Width of the base edge
+        y: Top y-coordinate of the trapezoid
+        h: Height of the trapezoid in pixels
+        val: Intensity value to fill (default: 1.0)
+
+    Returns:
+        numpy.ndarray: The modified image array
+    """
+    height = max(0, int(h))
+    if height <= 0:
+        return img
+    img_h, img_w = img.shape
+    for i in range(height):
+        t = 0.0 if height == 1 else i / (height - 1)
+        curr_x = int(round((1.0 - t) * top_x + t * base_x))
+        curr_w = int(round((1.0 - t) * top_w + t * base_w))
+        yy = y + i
+        if 0 <= yy < img_h and curr_w > 0:
+            start = max(0, curr_x)
+            end = min(img_w, curr_x + curr_w)
+            if start < end:
+                img[yy, start:end] = val
+    return img
+
+
+def draw_disk_approx(img, cx, cy, r, val=1.0):
+    """
+    Draw a filled disk (circle) approximation using a radius check within a bounding box.
+
+    Args:
+        img: Image array to draw on (modified in-place)
+        cx: Center x-coordinate
+        cy: Center y-coordinate
+        r: Radius in pixels
+        val: Intensity value to fill (default: 1.0)
+
+    Returns:
+        numpy.ndarray: The modified image array
+    """
+    radius = max(0, int(r))
+    if radius <= 0:
+        return img
+    img_h, img_w = img.shape
+    x0 = max(0, cx - radius)
+    x1 = min(img_w - 1, cx + radius)
+    y0 = max(0, cy - radius)
+    y1 = min(img_h - 1, cy + radius)
+    r2 = radius * radius
+    for yy in range(y0, y1 + 1):
+        dy = yy - cy
+        dy2 = dy * dy
+        # compute span in x using circle equation for efficiency
+        # but simple per-pixel check is fine at this resolution
+        for xx in range(x0, x1 + 1):
+            dx = xx - cx
+            if dx * dx + dy2 <= r2:
+                img[yy, xx] = val
+    return img
+
 def make_house_scene(size=64, noise=0.05, scale_factor=1.0, position_offset=(0, 0)):
     """
     Generate a synthetic house scene with body, roof, and door.
@@ -272,6 +344,12 @@ def make_varied_scene(scene_type='house', size=64, noise=0.05,
         return make_tent_scene(size, noise, scale_factor, (offset_x, offset_y))
     elif scene_type == 'tower':
         return make_tower_scene(size, noise, scale_factor, (offset_x, offset_y))
+    elif scene_type == 'castle':
+        return make_castle_scene(size, noise, scale_factor, (offset_x, offset_y))
+    elif scene_type == 'windmill':
+        return make_windmill_scene(size, noise, scale_factor, (offset_x, offset_y))
+    elif scene_type == 'lighthouse':
+        return make_lighthouse_scene(size, noise, scale_factor, (offset_x, offset_y))
     else:
         # Default to house
         return make_house_scene(size, noise, scale_factor, (offset_x, offset_y))
@@ -408,6 +486,215 @@ def make_tower_scene(size=64, noise=0.05, scale_factor=1.0, position_offset=(0, 
         wy = ty + (i + 1) * (th // (num_windows + 1)) - win_size // 2
         if 0 <= wx < size and 0 <= wy < size and wx + win_size <= size and wy + win_size <= size:
             draw_rect(img, wx, wy, win_size, win_size, 0.9)
+
+    # Noise
+    if noise > 0:
+        img += noise * np.random.randn(*img.shape).astype(np.float32)
+        img = np.clip(img, 0.0, 1.0)
+
+    return img
+
+
+def make_castle_scene(size=64, noise=0.05, scale_factor=1.0, position_offset=(0, 0)):
+    """
+    Generate a synthetic castle scene with wall, crenellations, side towers, and gate.
+
+    Components:
+    - Main wall (0.6)
+    - Crenellations along the top (0.85)
+    - Two side towers (0.65) with small caps (0.8)
+    - Central gate opening (0.3)
+
+    Returns:
+        numpy.ndarray: Generated castle scene as float32 array in [0, 1]
+    """
+    img = canvas(size)
+
+    # Main wall
+    wall_w = max(14, int((size * 0.6) * scale_factor))
+    wall_h = max(10, int((size * 0.28) * scale_factor))
+    wx = max(0, min(size - wall_w, size // 2 - wall_w // 2 + position_offset[0]))
+    wy = max(0, min(size - wall_h, size // 2 + position_offset[1]))
+    draw_rect(img, wx, wy, wall_w, wall_h, 0.6)
+
+    # Crenellations along top of wall
+    tooth_w = max(2, wall_w // 16)
+    tooth_h = max(2, wall_h // 4)
+    gap = max(1, tooth_w // 2)
+    num_teeth = max(3, (wall_w - gap) // (tooth_w + gap))
+    start_x = wx + (wall_w - (num_teeth * (tooth_w + gap) - gap)) // 2
+    y_top = max(0, wy - tooth_h)
+    for i in range(num_teeth):
+        tx = start_x + i * (tooth_w + gap)
+        if 0 <= tx < size and y_top >= 0 and tx + tooth_w <= size:
+            draw_rect(img, tx, y_top, tooth_w, tooth_h, 0.85)
+
+    # Side towers
+    tower_w = max(6, wall_w // 6)
+    tower_h = max(wall_h + tooth_h + 6, int(wall_h * 1.7))
+    # Left tower
+    ltx = max(0, wx - tower_w // 2)
+    lty = max(0, wy + wall_h - tower_h)
+    draw_rect(img, ltx, lty, tower_w, tower_h, 0.65)
+    # Right tower
+    rtx = min(size - tower_w, wx + wall_w - tower_w // 2)
+    rty = max(0, wy + wall_h - tower_h)
+    draw_rect(img, rtx, rty, tower_w, tower_h, 0.65)
+    # Tower caps
+    cap_h = max(2, tower_h // 8)
+    if lty - cap_h >= 0:
+        draw_rect(img, ltx, lty - cap_h, tower_w, cap_h, 0.8)
+    if rty - cap_h >= 0:
+        draw_rect(img, rtx, rty - cap_h, tower_w, cap_h, 0.8)
+
+    # Gate opening (centered on wall bottom)
+    gate_w = max(4, wall_w // 6)
+    gate_h = max(6, int(wall_h * 0.7))
+    gx = wx + wall_w // 2 - gate_w // 2
+    gy = wy + wall_h - gate_h
+    if gx + gate_w <= size and gy + gate_h <= size:
+        draw_rect(img, gx, gy, gate_w, gate_h, 0.3)
+
+    # Noise
+    if noise > 0:
+        img += noise * np.random.randn(*img.shape).astype(np.float32)
+        img = np.clip(img, 0.0, 1.0)
+
+    return img
+
+
+def make_windmill_scene(size=64, noise=0.05, scale_factor=1.0, position_offset=(0, 0)):
+    """
+    Generate a synthetic windmill scene with a tower, roof, hub, and blades.
+
+    Components:
+    - Tower body (0.6)
+    - Roof triangle (0.9)
+    - Circular hub (0.95)
+    - Four blades: horizontal/vertical (rects) and two diagonals (trapezoids) (0.85)
+
+    Returns:
+        numpy.ndarray: Generated windmill scene as float32 array in [0, 1]
+    """
+    img = canvas(size)
+
+    # Tower
+    tw = max(6, int((size * 0.18) * scale_factor))
+    th = max(18, int((size * 0.55) * scale_factor))
+    tx = max(0, min(size - tw, size // 2 - tw // 2 + position_offset[0]))
+    ty = max(0, min(size - th, size // 2 - th // 4 + position_offset[1]))
+    draw_rect(img, tx, ty, tw, th, 0.6)
+
+    # Roof triangle atop tower
+    roof_h = max(4, th // 6)
+    if ty - roof_h >= 0:
+        draw_triangle(img, tx, ty - roof_h, tw, roof_h, 0.9)
+
+    # Hub
+    cx = tx + tw // 2
+    cy = max(0, ty - 1)
+    hub_r = max(2, tw // 4)
+    draw_disk_approx(img, cx, cy, hub_r, 0.95)
+
+    # Blades lengths and thickness
+    blade_len = max(10, int(size * 0.22 * scale_factor))
+    blade_th = max(2, tw // 4)
+
+    # Horizontal blade
+    hx = max(0, cx - blade_len)
+    hw = min(size - hx, blade_len * 2)
+    draw_rect(img, hx, max(0, cy - blade_th // 2), hw, blade_th, 0.85)
+
+    # Vertical blade
+    vy = max(0, cy - blade_len)
+    vh = min(size - vy, blade_len * 2)
+    draw_rect(img, max(0, cx - blade_th // 2), vy, blade_th, vh, 0.85)
+
+    # Diagonal blades using trapezoids to approximate slant
+    diag_len = blade_len
+    diag_th = blade_th
+    # Down-right
+    draw_trapezoid(
+        img,
+        top_x=cx,
+        top_w=diag_th,
+        base_x=min(size - 1, cx + diag_len),
+        base_w=diag_th,
+        y=max(0, cy - diag_len // 8),
+        h=min(size - max(0, cy - diag_len // 8), diag_len),
+        val=0.85,
+    )
+    # Up-right
+    start_y = max(0, cy - diag_len)
+    height = min(size - start_y, diag_len)
+    draw_trapezoid(
+        img,
+        top_x=cx,
+        top_w=diag_th,
+        base_x=min(size - 1, cx + diag_len),
+        base_w=diag_th,
+        y=start_y,
+        h=height,
+        val=0.85,
+    )
+
+    # Noise
+    if noise > 0:
+        img += noise * np.random.randn(*img.shape).astype(np.float32)
+        img = np.clip(img, 0.0, 1.0)
+
+    return img
+
+
+def make_lighthouse_scene(size=64, noise=0.05, scale_factor=1.0, position_offset=(0, 0)):
+    """
+    Generate a synthetic lighthouse with striped body, top cap, and light beam.
+
+    Components:
+    - Striped body (alternating 0.6/0.8)
+    - Lantern room/top cap (0.9)
+    - Light beam as a slanted trapezoid (1.0 -> clipped)
+
+    Returns:
+        numpy.ndarray: Generated lighthouse scene as float32 array in [0, 1]
+    """
+    img = canvas(size)
+
+    # Body
+    bw = max(7, int((size * 0.16) * scale_factor))
+    bh = max(26, int((size * 0.65) * scale_factor))
+    bx = max(0, min(size - bw, size // 3 - bw // 2 + position_offset[0]))
+    by = max(0, min(size - bh, size // 2 - bh // 3 + position_offset[1]))
+
+    # Draw stripes
+    stripe_h = max(3, bh // 8)
+    stripes = max(4, bh // stripe_h)
+    for i in range(stripes):
+        sy = by + i * stripe_h
+        if sy >= by + bh:
+            break
+        h = min(stripe_h, by + bh - sy)
+        val = 0.6 if i % 2 == 0 else 0.8
+        draw_rect(img, bx, sy, bw, h, val)
+
+    # Lantern room/top cap
+    cap_h = max(3, bh // 10)
+    cap_y = max(0, by - cap_h)
+    draw_rect(img, bx, cap_y, bw, cap_h, 0.9)
+
+    # Light beam to the right using trapezoid
+    beam_h = max(4, cap_h + 2)
+    beam_top_x = bx + bw
+    beam_base_x = min(size - 1, beam_top_x + int(size * 0.35))
+    beam_y = max(0, cap_y + cap_h // 2 - beam_h // 2)
+    draw_trapezoid(img, beam_top_x, 2, beam_base_x, max(4, bw // 2), beam_y, beam_h, 1.0)
+
+    # Small door at bottom
+    dw = max(3, bw // 3)
+    dh = max(5, bh // 6)
+    dx = bx + bw // 2 - dw // 2
+    dy = by + bh - dh
+    draw_rect(img, dx, dy, dw, dh, 0.3)
 
     # Noise
     if noise > 0:


### PR DESCRIPTION
Add new `draw_trapezoid` and `draw_disk_approx` helpers and implement `castle`, `windmill`, and `lighthouse` scenes to expand synthetic dataset variety.

---
<a href="https://cursor.com/background-agent?bcId=bc-607f6eaf-b436-4df3-a877-3294a75eb431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-607f6eaf-b436-4df3-a877-3294a75eb431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

